### PR TITLE
Fix WebSocket protocol selection

### DIFF
--- a/webapp/static/script.js
+++ b/webapp/static/script.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const WS_URL = `ws://${window.location.host}/ws/commands`;
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const WS_URL = `${protocol}://${window.location.host}/ws/commands`;
     let socket;
     let fullTfConfig = {}; // Store the full TF config globally
 


### PR DESCRIPTION
## Summary
- select ws or wss for WebSocket URL based on page protocol to avoid mixed-content issues

## Testing
- `python -m py_compile webapp/main.py`
- `node --check webapp/static/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68952c08473c8326b6e4c22fa2d971e3