### PR TITLE
feat: add VMware vSphere provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ You can enable the Unifi provider to enable your Unifi controller to make dedica
 
 You can enable the Minio provider to store your tofu/terraform state in S3 instead of your local computer. This is recommended for your production clusters.
 
+You can enable the VMware vSphere provider to connect to a vCenter server and manage resources in a vSphere environment.
+
 Use the new `ccr` command to enable the provider of your choice.
 
 ```shell
@@ -187,6 +189,7 @@ This will guide you through setting
 - **Proxmox Credentials**: Refer to for creating API tokens.
 - **Unifi Credentials**: (optional, needs to be toggled on first) Create a service account in the Unifi Controller with Site Admin permissions for the Network app.
 - **Minio Access Key/Secret**: (optional, needs to be toggled on first) Create a minio access key that has read/write access to the bucket specified in `terraform/variables.tf`.
+- **vSphere Credentials**: (optional, needs to be toggled on first) Provide the vCenter server address, username, and password.
 
 ### 7. Configure Clusters
 

--- a/scripts/configure_secrets.sh
+++ b/scripts/configure_secrets.sh
@@ -51,9 +51,9 @@ tf_variables=(
 #     "unifi_password|Enter the Unifi service account password"
 #     "minio_access_key|Enter the MinIO access key"
 #     "minio_secret_key|Enter the MinIO secret key"
-#     "vsphere_server|Enter the vCenter server address"
-#     "vsphere_user|Enter the vCenter username"
-#     "vsphere_password|Enter the vCenter password"
+    "vsphere_server|Enter the vCenter server address"
+    "vsphere_user|Enter the vCenter username"
+    "vsphere_password|Enter the vCenter password"
 )
 
 # Function to prompt and save secrets

--- a/scripts/configure_secrets.sh
+++ b/scripts/configure_secrets.sh
@@ -51,6 +51,9 @@ tf_variables=(
 #     "unifi_password|Enter the Unifi service account password"
 #     "minio_access_key|Enter the MinIO access key"
 #     "minio_secret_key|Enter the MinIO secret key"
+#     "vsphere_server|Enter the vCenter server address"
+#     "vsphere_user|Enter the vCenter username"
+#     "vsphere_password|Enter the vCenter password"
 )
 
 # Function to prompt and save secrets

--- a/scripts/toggle_providers.sh
+++ b/scripts/toggle_providers.sh
@@ -8,6 +8,7 @@ usage() {
   echo "Providers that can be toggled:"
   echo "  * Unifi - toggling off will stop trying to make networks/vlans with Unifi."
   echo "  * Minio - toggling off will store all terraform state locally instead of in Minio's S3-compatible storage"
+  echo "  * VMware vSphere - toggling on will allow Terraform to manage resources in a vSphere environment"
 }
 
 # Prompt the user
@@ -15,6 +16,8 @@ echo -e "${YELLOW}Are you using MinIO to store the Terraform state? (y/n)${ENDCO
 read -r use_minio
 echo -e "${YELLOW}Are you using Unifi as part of your setup? (y/n)$ENDCOLOR"
 read -r use_unifi
+echo -e "${YELLOW}Are you using VMware vSphere as part of your setup? (y/n)$ENDCOLOR"
+read -r use_vsphere
 
 # General function to toggle a block in a Terraform file using awk for balanced braces
 toggle_tf_block() {
@@ -81,9 +84,11 @@ unifi_file="$REPO_PATH/terraform/unifi.tf"
 # Toggle specific blocks in providers.tf based on user input
 toggle_tf_block "aws =" "$use_minio" "$providers_file"
 toggle_tf_block "unifi =" "$use_unifi" "$providers_file"
+toggle_tf_block "vsphere =" "$use_vsphere" "$providers_file"
 toggle_tf_block 'backend "s3"' "$use_minio" "$providers_file"
 toggle_tf_block 'provider "aws"' "$use_minio" "$providers_file"
 toggle_tf_block 'provider "unifi"' "$use_unifi" "$providers_file"
+toggle_tf_block 'provider "vsphere"' "$use_vsphere" "$providers_file"
 toggle_tf_block 'resource "unifi_network"' "$use_unifi" "$unifi_file"
 
 # Toggle minio-related lines in configure_secrets.sh
@@ -98,6 +103,11 @@ toggle_secrets_lines "minio_endpoint" "$use_minio" "$variables_file"
 # Toggle unifi-related lines in configure_secrets.sh
 toggle_secrets_lines "unifi_username" "$use_unifi" "$secrets_file"
 toggle_secrets_lines "unifi_password" "$use_unifi" "$secrets_file"
+
+# Toggle vsphere-related lines in configure_secrets.sh
+toggle_secrets_lines "vsphere_server" "$use_vsphere" "$secrets_file"
+toggle_secrets_lines "vsphere_user" "$use_vsphere" "$secrets_file"
+toggle_secrets_lines "vsphere_password" "$use_vsphere" "$secrets_file"
 
 # Toggle unifi-related lines in variables.tf
 toggle_secrets_lines "unifi_api_url" "$use_unifi" "$variables_file"

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,36 +1,40 @@
 terraform {
   required_providers {
-#     aws = {
-#       source  = "hashicorp/aws"
-#       version = "5.90.0"
-#     }
+    #     aws = {
+    #       source  = "hashicorp/aws"
+    #       version = "5.90.0"
+    #     }
     proxmox = {
       source  = "bpg/proxmox"
       version = "0.73.1"
     }
-#     unifi = {
-#       source  = "paultyng/unifi"
-#       version = "0.41.0"
-#     }
+    # vsphere = {
+    #   source  = "hashicorp/vsphere"
+    #   version = "2.6.1"
+    # }
+    #     unifi = {
+    #       source  = "paultyng/unifi"
+    #       version = "0.41.0"
+    #     }
   }
 
-#   backend "s3" {
-#     bucket     = local.minio_bucket
-#     key        = "cluster_creator.tfstate"
-#     region     = local.minio_region
-#     access_key = var.minio_access_key
-#     secret_key = var.minio_secret_key
-# 
-#     endpoints = {
-#       s3 = local.minio_endpoint
-#     }
-# 
-#     use_path_style              = true
-#     skip_credentials_validation = true
-#     skip_metadata_api_check     = true
-#     skip_region_validation      = true
-#     skip_requesting_account_id  = true
-#   }
+  #   backend "s3" {
+  #     bucket     = local.minio_bucket
+  #     key        = "cluster_creator.tfstate"
+  #     region     = local.minio_region
+  #     access_key = var.minio_access_key
+  #     secret_key = var.minio_secret_key
+  # 
+  #     endpoints = {
+  #       s3 = local.minio_endpoint
+  #     }
+  # 
+  #     use_path_style              = true
+  #     skip_credentials_validation = true
+  #     skip_metadata_api_check     = true
+  #     skip_region_validation      = true
+  #     skip_requesting_account_id  = true
+  #   }
 }
 
 # provider "aws" {
@@ -56,12 +60,19 @@ terraform {
 #   allow_insecure = true
 # }
 
+# provider "vsphere" {
+#   user           = var.vsphere_user
+#   password       = var.vsphere_password
+#   vsphere_server = var.vsphere_server
+#   allow_unverified_ssl = true
+# }
+
 provider "proxmox" {
-  endpoint   = "https://${local.proxmox_host}:8006/api2/json"
-  api_token  = var.proxmox_api_token
+  endpoint  = "https://${local.proxmox_host}:8006/api2/json"
+  api_token = var.proxmox_api_token
   ssh {
     username = var.proxmox_username
     agent    = true
   }
-  insecure   = true
+  insecure = true
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -61,9 +61,9 @@ terraform {
 # }
 
 # provider "vsphere" {
-#   user           = var.vsphere_user
-#   password       = var.vsphere_password
-#   vsphere_server = var.vsphere_server
+#   user                 = local.vsphere_user
+#   password             = local.vsphere_password
+#   vsphere_server       = local.vsphere_server
 #   allow_unverified_ssl = true
 # }
 

--- a/terraform/secrets.tf.example
+++ b/terraform/secrets.tf.example
@@ -17,6 +17,7 @@ variable "proxmox_api_token" {
   default = "terraform@pve!provider=TOKEN"
 }
 
+# VMware vSphere credentials
 variable "vsphere_server" {
   description = "The vCenter server address."
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -2,6 +2,9 @@ locals {
     proxmox_host   = "192.168.254.1"
     proxmox_node   = "pve01"
     template_vm_id = 9000
+    vsphere_server   = var.vsphere_server
+    vsphere_user     = var.vsphere_user
+    vsphere_password = var.vsphere_password
 #     unifi_api_url  = "https://10.0.0.1/"
 #     minio_endpoint = "https://s3.christensencloud.us"
 #     minio_region   = "default"


### PR DESCRIPTION
## Summary
- allow Terraform to optionally use the VMware vSphere provider
- extend provider toggling and secrets setup to support vSphere credentials
- document vSphere provider usage and placeholders

## Testing
- `terraform init -backend=false`
- `terraform validate`
- `shellcheck scripts/toggle_providers.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689530a8780883269534c6184c560517